### PR TITLE
Add REQUEST_URI to basepath

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
 
     $app = new CmOta();
     $app
-    ->setConfig( 'basePath', 'http://'.$_SERVER['HTTP_HOST'] )
+    ->setConfig( 'basePath', 'http://'.$_SERVER['HTTP_HOST'].substr($_SERVER['REQUEST_URI'], 0, -4))
     ->setConfig( 'memcached.host', 'localhost' )
     ->setConfig( 'memcached.port', 11211 )
     ->enableMemcached()


### PR DESCRIPTION
This fixes the basePath if the REST server URL is not located in the root of DocumentRoot (ie; http://192.168.1.1/CyanogenModOTA/api).  HTTP_HOST only shows the server's IP address, but not the full path to the "CyanogenModOTA" directory.  REQUEST_URI is necessary to generate a complete path to the "CyanogenModOTA" directory. Also note that composer installs to CyanogenModOTA with the provided installation instructions.
