### PR TITLE
Automatically support having a path to the server

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
 
     $app = new CmOta();
     $app
-    ->setConfig( 'basePath', 'http://'.$_SERVER['HTTP_HOST'] )
+    ->setConfig( 'basePath', 'http://'.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']) )
     ->setConfig( 'memcached.host', 'localhost' )
     ->setConfig( 'memcached.port', 11211 )
     ->enableMemcached()


### PR DESCRIPTION
If the user has installed the server at a path other than the root of their server, figure that out and initialise basePath with it.

This fixes issue #17.