### PR TITLE
Get contents of build.prop before reading values

### DIFF
--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -65,8 +65,8 @@
             $this->filePath = $physicalPath . '/' . $fileName;
             $this->channel = $this->_getChannel( str_replace( range( 0 , 9 ), '', $tokens[4] ), $tokens[1], $tokens[2] );
             $this->filename = $fileName;
-            $this->timestamp = $this->getBuildPropValue( 'ro.build.date.utc' );
             $this->buildProp = explode( "\n", @file_get_contents('zip://'.$this->filePath.'#system/build.prop') );
+            $this->timestamp = $this->getBuildPropValue( 'ro.build.date.utc' );
             $this->incremental = $this->getBuildPropValue( 'ro.build.version.incremental' );
             $this->apiLevel = $this->getBuildPropValue( 'ro.build.version.sdk' );
             $this->model = $this->getBuildPropValue( 'ro.cm.device' );


### PR DESCRIPTION
Get the contents of build.prop before reading
its values to prevent internal error.

Fixes: "Use the internal ROM timestamp from build.prop"