### PR TITLE
Support device names with underscores in name extraction

### DIFF
--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -65,7 +65,7 @@
                       LINEAGE => [SIGNED] (ex. signed)
                 )
             */
-            preg_match_all( '/([A-Za-z0-9]+)?-([0-9\.]+)-([\d_]+)?-([\w+]+)-([A-Za-z0-9]+)?-?([\w+]+)?/', $fileName, $tokens );
+            preg_match_all( '/([A-Za-z0-9]+)?-([0-9\.]+)-([\d_]+)?-([\w+]+)-([A-Za-z0-9_]+)?-?([\w+]+)?/', $fileName, $tokens );
 
             $tokens = $this->removeTrailingDashes( $tokens );
 


### PR DESCRIPTION
Without this it would interpret anything after the underscore as the lineage signed marker breaking the server.