### PR TITLE
fix loading prop file from alternate location

### DIFF
--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -76,7 +76,12 @@
             // Try to load the build.prop from two possible paths:
             // - builds/CURRENT_ZIP_FILE.zip/system/build.prop
             // - builds/CURRENT_ZIP_FILE.zip.prop ( which must exist )
-            $this->buildProp = explode( "\n", @file_get_contents('zip://'.$this->filePath.'#system/build.prop') ?? @file_get_contents($this->filePath.'.prop') );
+            $propsFileContent = @file_get_contents('zip://'.$this->filePath.'#system/build.prop');
+            if ($propsFileContent === false || empty($propsFileContent)) {
+                $propsFileContent = @file_get_contents($this->filePath.'.prop');
+            }
+            $this->buildProp = explode( "\n", $propsFileContent );
+
             // Try to fetch build.prop values. In some cases, we can provide a fallback, in other a null value will be given
             $this->timestamp = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? filemtime($this->filePath) );
             $this->incremental = $this->getBuildPropValue( 'ro.build.version.incremental' ) ?? '';


### PR DESCRIPTION
When loading the file from zip fails, `@file_get_contents(...)` evaluates to `false`, not `null`, so the null coalescing operator did not continue with the second option.

This change replaces it with a more explicit and correctly behaving logic.