### PR TITLE
Read channel from build.prop ro.lineage.releasetype

### DIFF
--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -70,7 +70,6 @@
             $tokens = $this->removeTrailingDashes( $tokens );
 
             $this->filePath = $physicalPath . '/' . $fileName;
-            $this->channel = $this->_getChannel( str_replace( range( 0 , 9 ), '', $tokens[4] ), $tokens[1], $tokens[2] );
             $this->filename = $fileName;
 
             // Try to load the build.prop from two possible paths:
@@ -83,6 +82,7 @@
             $this->buildProp = explode( "\n", $propsFileContent );
 
             // Try to fetch build.prop values. In some cases, we can provide a fallback, in other a null value will be given
+            $this->channel = $this->_getChannel( $this->getBuildPropValue( 'ro.lineage.releasetype' ) ?? str_replace( range( 0 , 9 ), '', $tokens[4] ), $tokens[1], $tokens[2] );
             $this->timestamp = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? filemtime($this->filePath) );
             $this->incremental = $this->getBuildPropValue( 'ro.build.version.incremental' ) ?? '';
             $this->apiLevel = $this->getBuildPropValue( 'ro.build.version.sdk' ) ?? '';


### PR DESCRIPTION
Hi,

Lineage builders can add a `ro.lineage.releasetype` property on build.props, that is used by updater to fetch API

For example, if I set release type to `Personnal-Release`, for akari phone, Lineage updater will fetch `https://url/api/v1/akari/personnal-release/{version}` to check if update is available.
And builder will add a `ro.lineage.releasetype=Personnal-Release` on build.prop file.

I suggest that, if this property exists, we will use it as channel name, instead of parsing zip file name (in this case, parsing will return `Personnal` instead of `Personnal-Release`).
If property does not exists, fallback to the parsed name.

I only tested Lineage 18.1 builds, I dont know if it's really different on older builds.
Thanks