### PR TITLE
Allow specifying application root path via the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ docker run \
 
 then finally visit http://localhost/ to see the REST Server up and running.
 
+The root URL (used to generate ROM URLs in the `/api` endpoint) can be set using the `LINEAGEOTA_BASE_PATH` variable.
+
 ## Where to move built ROM ZIPs
 
 - Full builds should be uploaded into `builds/full` directory.

--- a/index.php
+++ b/index.php
@@ -54,7 +54,12 @@
     else
         $protocol = 'http://';
 
+    if ( isset($_ENV['LINEAGEOTA_BASE_PATH']) )
+        $base_path = $_ENV['LINEAGEOTA_BASE_PATH'];
+    else
+        $base_path = $protocol.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']);
+
     $app = new CmOta();
     $app
-    ->setConfig( 'basePath', $protocol.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']) )
+    ->setConfig( 'basePath', $base_path )
     ->run();


### PR DESCRIPTION
LineageOTA needs to know the full external URL to itself in order to generate correct links in the JSON emitted by the `/api` endpoint.

In typical circumstances, no manual configuration is necessary - it is able to infer it from the URL that it is accessed by, or from the `Forwarded` header, or from the `ro.build.ota.url` property from `.prop` files. However, when it is running behind a reverse proxy (and in the absence of the `.ota.url` property) , the URL prefix is not available to LineageOTA, so unless it matches the prefix on the local webserver, it is unable to construct a correct URL to itself in this scenario.

To allow it to do so, a mechanism must be added to provide this information to it. There are two straight-forward approaches:

- Provide this information externally, i.e. using a configuration file or an environment variable

- Provide this information in an HTTP header, in the same manner as the `Forwarded` header.

In this pull request, the former method is implemented. The rationale for not using the latter method is that administrators would need to be aware of this change and override or block the header in their reverse proxy configuration, to prevent it being forwarded (and thus spoofed).

Fixes #75.