### PR TITLE
Add Gihub Caching Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,33 @@ I am not sure how much this may help anyway, but this must be used as an extreme
 
 ## Github hosting
 
-If you want to host your roms on Github you can put your repository name inside the [`github.json`](github.json) file, like this example below:
+If you want to host your roms on Github you can put your repository names inside the [`github.json`](github.json) file, like this example below:
 ```json
 [
   {
-    "name": "ADeadTrousers/android_device_Unihertz_Atom_XL"
+    "name": "ADeadTrousers/android_device_Unihertz_Atom_XL_EEA",
+    "name": "ADeadTrousers/android_device_Unihertz_Atom_XL_TEE"
   }
 ]
 ```
+
+Each line should point to a repository for a single device and have Github releases with attached files.  At a minimum there should be the following files in each release:
+
+* build.prop
+* OTA release zip
+* .md5sum list
+
+The md5sum file contains a list of hash values for the the OTA zip as well as any other files you included in the release that need them.  Each line of the md5sum should be of the format:
+
+```
+HASHVALUE	FILENAME
+```
+
+The filename should not contain any directory information.
+
+You may also include a changelog file in html format.  Note, any html file included in the release file list will be included as a changelog.
+
+By default, Github release information is cached for 1 day, by storing it in a json file on your webserver.  This requires the webserver to have write access to the directory.  If you wish to force a refresh of the releases, simply delete the github.cache.json file.
 
 ## REST Server Unit Testing
 
@@ -102,10 +121,10 @@ cm.updater.uri=http://my.ota.uri/api/v1/{device}/{type}/{incr}
 # ...
 ```
 
-> As of [e930cf7](https://github.com/LineageOS/android_packages_apps_Updater/commit/e930cf7f67d10afcd933dec75879426126d8579a):  
-> Optional placeholders replaced at runtime:  
->   {device} - Device name  
->   {type} - Build type  
+> As of [e930cf7](https://github.com/LineageOS/android_packages_apps_Updater/commit/e930cf7f67d10afcd933dec75879426126d8579a):
+> Optional placeholders replaced at runtime:
+>   {device} - Device name
+>   {type} - Build type
 >   {incr} - Incremental version
 
 #### LineageOS ( >= 15.x)
@@ -122,10 +141,10 @@ Make always sure to provide a HTTPS based uri, otherwise the updater will reject
 
 > Since https://review.lineageos.org/#/c/191274/ is merged, the property `cm.updater.uri` is renamed to `lineage.updater.uri`. Make sure to update your entry.
 
-> As of [5252d60](https://github.com/LineageOS/android_packages_apps_Updater/commit/5252d606716c3f8d81617babc1293c122359a94d):  
-> Optional placeholders replaced at runtime:  
->   {device} - Device name  
->   {type} - Build type  
+> As of [5252d60](https://github.com/LineageOS/android_packages_apps_Updater/commit/5252d606716c3f8d81617babc1293c122359a94d):
+> Optional placeholders replaced at runtime:
+>   {device} - Device name
+>   {type} - Build type
 >   {incr} - Incremental version
 
 
@@ -138,6 +157,16 @@ In order to integrate this in your [CyanogenMod](https://github.com/lineageos/an
 > Using the `build.prop` instead offers an easy and smooth integration, which could potentially be used even in local builds that make use fully of the official repos, but only updates through a local OTA REST Server. For example, by using the [docker-lineage-cicd](https://github.com/julianxhokaxhiu/docker-lineage-cicd) project.
 
 ## Changelog
+
+### v?.?.?
+- Added Github caching support ( thanks to @toolstack )
+- Include github as a source repository ( thanks to @ADeadTrousers )
+- Accept LINEAGEOTA_BASE_PATH from environment to set the root URL ( thanks to @CyberShadow )
+- Read channel from build.prop ro.lineage.releasetype ( thanks to @tduboys )
+- fix loading prop file from alternate location ( thanks to @bananer )
+- Support device names with underscores in name extraction ( thanks to @bylaws )
+- Fix finding numbers on rom names (thanks to @erfanoabdi )
+- Fix loading prop file
 
 ### v2.9.0
 - Add PHP 7.4 compatibility: Prevent null array access on `isValid()` ( thanks to @McNutnut )

--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -155,6 +155,30 @@
             return $this->version;
         }
 
+        /**
+         * Export a JSON representation of the object values
+         * @return string the JSON data
+         */
+        public function exportData() {
+            return get_object_vars( $this );
+        }
+
+        /**
+         * Import a JSON representation of the object values
+         * @param string $data The data to import
+         * @return object return ourselves
+         */
+        public function importData( $data ) {
+            if( is_array( $data ) ) {
+                foreach( $data as $key => $value ) {
+                    if( property_exists( $this, $key ) ) {
+                        $this->$key = $value;
+                    }
+                }
+            }
+
+            return $this;
+        }
     	/* Utility / Internal */
     	
         /**

--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -42,6 +42,7 @@
         protected $uid = null;
         protected $size = '';
         protected $md5 = '';
+        protected $version = '';
 
         /**
          * Check if the current build is valid within the current request

--- a/src/Helpers/BuildGithub.php
+++ b/src/Helpers/BuildGithub.php
@@ -102,27 +102,6 @@
         }
 
         /**
-         * Check if the current build is valid within the current request
-         * @param type $params The params dictionary inside the current POST request
-         * @return boolean True if valid, False if not.
-         */
-    	public function isValid($params){
-            if ( $params === NULL ) return true;  // Assume valid if no parameters
-
-            $ret = false;
-
-            if ( $params['device'] == $this->model ) {
-                if ( count($params['channels']) > 0 ) {
-                    foreach ( $params['channels'] as $channel ) {
-                        if ( strtolower($channel) == $this->channel ) $ret = true;
-                    }
-                }
-            }
-
-            return $ret;
-        }
-
-        /**
          * Create a delta build based from the current build to the target build.
          * @param type $targetToken The target build from where to build the Delta
          * @return array/boolean Return an array performatted with the correct data inside, otherwise false if not possible to be created

--- a/src/Helpers/BuildGithub.php
+++ b/src/Helpers/BuildGithub.php
@@ -37,62 +37,68 @@
          * and make them available for the next time.
          * @param array $release The information provided by github API
          */
-    	public function __construct($release) {
+    	public function __construct($release, $data=False) {
     	    $archives = array();
     	    $properties = array();
     	    $md5sums = array();
     	    $changelogs = array();
-            // Split all Assets because they are not properly sorted
-            foreach ( $release['assets'] as $asset ) {
-                switch ( $asset['content_type'] ) {
-                    case 'application/zip':
-                        array_push($archives,$asset);
-                        break;
-                    default:
-                        $extension = pathinfo($asset['name'], PATHINFO_EXTENSION);
-                        switch ( $extension ) {
-                            case 'txt':
-                            case 'html':
-                                array_push($changelogs,$asset);
-                                break;
-                            case 'md5sum':
-                                array_push($md5sums,$asset);
-                                break;
-                            case 'prop':
-                                array_push($properties,$asset);
-                                break;
-                        }
-                }
-            }
-            foreach ( $archives as $archive ) {            
-                $tokens = $this->parseFilenameFull($archive['name']);         
-                $this->filePath = $archive['browser_download_url'];
-                $this->url = $archive['browser_download_url'];
-                $this->channel = $this->_getChannel( str_replace( range( 0 , 9 ), '', $tokens[4] ), $tokens[1], $tokens[2] );
-                $this->filename = $archive['name'];
-                $this->timestamp = strtotime( $archive['updated_at'] );
-                $this->model = $tokens[1] == 'cm' ? $tokens[6] : $tokens[5];
-                $this->version = $tokens[2];
-                $this->size = $archive['size'];
-            }
-            foreach ( $properties as $property ) {            
-                $this->buildProp = explode( "\n", file_get_contents( $property['browser_download_url'] ) );
-                $this->timestamp = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? $this->timestamp );
-                $this->incremental = $this->getBuildPropValue( 'ro.build.version.incremental' ) ?? '';
-                $this->apiLevel = $this->getBuildPropValue( 'ro.build.version.sdk' ) ?? '';
-                $this->model = $this->getBuildPropValue( 'ro.lineage.device' ) ?? $this->getBuildPropValue( 'ro.cm.device' ) ?? $this->model;
-            }
-            foreach ( $md5sums as $md5sum ) { 
-                $md5 = $this->parseMD5($md5sum['browser_download_url']);
-                if (array_key_exists($this->filename,$md5)) {
-                    $this->md5 = $md5[$this->filename];
-                }     
-            }
-            foreach ( $changelogs as $changelog ) {
-                $this->changelogUrl = $changelog['browser_download_url'];
-            }
 
-            $this->uid = hash( 'sha256', $this->timestamp.$this->model.$this->apiLevel, false );
+            // If data is passed in, just import it instead of doing the work to construct the object from scratch
+            if( is_array( $data ) ) {
+                $this->importData( $data );
+            } else {
+                // Split all Assets because they are not properly sorted
+                foreach ( $release['assets'] as $asset ) {
+                    switch ( $asset['content_type'] ) {
+                        case 'application/zip':
+                            array_push($archives,$asset);
+                            break;
+                        default:
+                            $extension = pathinfo($asset['name'], PATHINFO_EXTENSION);
+                            switch ( $extension ) {
+                                case 'txt':
+                                case 'html':
+                                    array_push($changelogs,$asset);
+                                    break;
+                                case 'md5sum':
+                                    array_push($md5sums,$asset);
+                                    break;
+                                case 'prop':
+                                    array_push($properties,$asset);
+                                    break;
+                            }
+                    }
+                }
+                foreach ( $archives as $archive ) {
+                    $tokens = $this->parseFilenameFull($archive['name']);
+                    $this->filePath = $archive['browser_download_url'];
+                    $this->url = $archive['browser_download_url'];
+                    $this->channel = $this->_getChannel( str_replace( range( 0 , 9 ), '', $tokens[4] ), $tokens[1], $tokens[2] );
+                    $this->filename = $archive['name'];
+                    $this->timestamp = strtotime( $archive['updated_at'] );
+                    $this->model = $tokens[1] == 'cm' ? $tokens[6] : $tokens[5];
+                    $this->version = $tokens[2];
+                    $this->size = $archive['size'];
+                }
+                foreach ( $properties as $property ) {
+                    $this->buildProp = explode( "\n", file_get_contents( $property['browser_download_url'] ) );
+                    $this->timestamp = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? $this->timestamp );
+                    $this->incremental = $this->getBuildPropValue( 'ro.build.version.incremental' ) ?? '';
+                    $this->apiLevel = $this->getBuildPropValue( 'ro.build.version.sdk' ) ?? '';
+                    $this->model = $this->getBuildPropValue( 'ro.lineage.device' ) ?? $this->getBuildPropValue( 'ro.cm.device' ) ?? $this->model;
+                }
+                foreach ( $md5sums as $md5sum ) {
+                    $md5 = $this->parseMD5($md5sum['browser_download_url']);
+                    if (array_key_exists($this->filename,$md5)) {
+                        $this->md5 = $md5[$this->filename];
+                    }
+                }
+                foreach ( $changelogs as $changelog ) {
+                    $this->changelogUrl = $changelog['browser_download_url'];
+                }
+
+                $this->uid = hash( 'sha256', $this->timestamp.$this->model.$this->apiLevel, false );
+            }
         }
 
         /**

--- a/src/Helpers/Builds.php
+++ b/src/Helpers/Builds.php
@@ -176,7 +176,9 @@
                 foreach( $data_set as $build_data ) {
                     $build = new BuildGithub(array(), $build_data);
 
-                    array_push( $this->builds, $build );
+                    if ( $build->isValid( $this->postData['params'] ) ) {
+                        array_push( $this->builds, $build );
+                    }
                 }
             } else {
                 // Get Repos with potential OTA releases

--- a/src/Helpers/Builds.php
+++ b/src/Helpers/Builds.php
@@ -195,9 +195,11 @@
                         foreach ( $releases as $release )  {
                             $build = new BuildGithub( $release );
 
+                            // Store this build to the cache
+                            array_push( $githubBuilds, $build->exportData() );
+
                             if ( $build->isValid( $this->postData['params'] ) ) {
                                 array_push( $this->builds, $build );
-                                array_push( $githubBuilds, $build->exportData() );
                             }
                         }
                     }


### PR DESCRIPTION
The new Github release support has a significant drawback as it has to query the Github API each time a device queries the updater and download all releases for all repos.  This requires a significant amount of network traffic, that scales rapidly if you have multiple devices and releases supported.

To solve this issue, I've added a caching mechanism to the Github support, so that release information is stored on the local webserver and refreshed once a day, as releases tend to be weekly or monthly .