### PR TITLE
Update Flight version and PHP requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Got a question? Not sure where it should be made? See [CONTRIBUTING](CONTRIBUTIN
 ## Requirements
 
 - Apache mod_rewrite enabled
-- PHP >= 5.3.0
+- PHP >= 7.4
 - PHP ZIP Extension
 - Composer ( if installing via CLI )
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     }
   ],
   "require": {
-    "mikecao/flight": "1.*",
+    "mikecao/flight": "2.*",
     "julianxhokaxhiu/dotnotation": "dev-master",
     "ext-zip": "*"
   },


### PR DESCRIPTION
You may not wish to merge this, as Flight 2.0 requires PHP 7.4, but I think dropping support for PHP 5 is a resonable thing at this point.