### PR TITLE
Use date on the file name

### DIFF
--- a/src/Helpers/BuildLocal.php
+++ b/src/Helpers/BuildLocal.php
@@ -58,9 +58,19 @@
 
                 $this->buildProp = explode( "\n", $propsFileContent );
 
+                if ( $tokens['date'] == '' ) {
+                    $timestamp = filemtime( $this->filePath );
+                } else {
+                    $timezone = date_default_timezone_get();
+                    date_default_timezone_set('Pacific/Kiritimati'); // the earliest time zone on Earth UTC+14:00
+                    $d = date_parse_from_format('Ymd', $tokens['date']);
+                    $timestamp = mktime(0, 0, 0, $d['month'], $d['day'], $d['year']);
+                    date_default_timezone_set($timezone);
+                }
+
                 // Try to fetch build.prop values. In some cases, we can provide a fallback, in other a null value will be given
                 $this->channel      = $this->_getChannel( $this->getBuildPropValue( 'ro.lineage.releasetype' ) ?? str_replace( range( 0 , 9 ), '', $tokens['channel'] ), $tokens['type'], $tokens['version'] );
-                $this->timestamp    = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? filemtime( $this->filePath ) );
+                $this->timestamp    = intval( $this->getBuildPropValue( 'ro.build.date.utc' ) ?? $timestamp );
                 $this->incremental  = $this->getBuildPropValue( 'ro.build.version.incremental' ) ?? '';
                 $this->apiLevel     = $this->getBuildPropValue( 'ro.build.version.sdk' ) ?? '';
                 $this->model        = $this->getBuildPropValue( 'ro.lineage.device' ) ?? $this->getBuildPropValue( 'ro.cm.device' ) ?? $tokens['model'];


### PR DESCRIPTION
Usually we build and place the zip file to OTA server and in this process always time of the zip file on OTA server is newer than the actual build date
and without prop file to read "ro.build.date.utc" the timestamp value is the one coming from filesystem

so updater app keeps showing new update is available because rom timestamp (ro.build.date.utc) is older than the json of updater server

With this change we calculate the earliest possible timestamp that can be used for the file
