### PR TITLE
Keep experimental type for non-lineage roms

### DIFF
--- a/src/Helpers/Build.php
+++ b/src/Helpers/Build.php
@@ -273,8 +273,8 @@
             if( $token > '' ) {
                 $ret = $token;
 
-                if( $token == 'experimental' && ( $type == 'cm' || version_compare ( $version, '14.1', '<' ) ) ) $ret = 'snapshot';
-                if( $token == 'unofficial' && ( $type == 'cm' || version_compare ( $version, '14.1', '<' ) ) ) $ret = 'nightly';
+                if( $token == 'experimental' && ( $type == 'cm' || ( $type == 'lineage' && version_compare ( $version, '14.1', '<' ) ) ) ) $ret = 'snapshot';
+                if( $token == 'unofficial' && ( $type == 'cm' || ( $type == 'lineage' && version_compare ( $version, '14.1', '<' ) ) ) ) $ret = 'nightly';
             }
 
             return $ret;


### PR DESCRIPTION
Me and probably others use this server for non-lineage roms but after https://github.com/julianxhokaxhiu/LineageOTA/commit/25e97721feeda59d9fa72cdf4f82f6cb31087d7b server reports "experimental" type as "snapshot" so lets just keep this type swapping only for lineage/cm

* Same thing about unofficial/nightly